### PR TITLE
change selectors to use with atom >=1.13

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,18 +1,19 @@
-atom-text-editor.editor,
-atom-text-editor.editor .gutter {
+atom-text-editor,
+atom-text-editor .gutter {
   background-color: #182227;
   color: #F0F0F0;
 }
 
-atom-text-editor.editor.is-focused .cursor {
+atom-text-editor.is-focused .cursor {
   border-color: #9EA7A6;
 }
 
-atom-text-editor.editor.is-focused .selection .region {
+atom-text-editor.is-focused .selection .region {
   background-color: rgba(221, 240, 255, 0.2);
 }
 
-atom-text-editor.editor.is-focused .line-number.cursor-line-no-selection, .editor.is-focused .line.cursor-line {
+atom-text-editor.is-focused .line-number.cursor-line-no-selection,
+atom-text-editor.is-focused .line.cursor-line {
   background-color: rgba(255, 255, 255, 0.1);
 }
 

--- a/index.less
+++ b/index.less
@@ -1,240 +1,241 @@
-.editor, .editor .gutter {
+atom-text-editor.editor,
+atom-text-editor.editor .gutter {
   background-color: #182227;
   color: #F0F0F0;
 }
 
-.editor.is-focused .cursor {
+atom-text-editor.editor.is-focused .cursor {
   border-color: #9EA7A6;
 }
 
-.editor.is-focused .selection .region {
+atom-text-editor.editor.is-focused .selection .region {
   background-color: rgba(221, 240, 255, 0.2);
 }
 
-.editor.is-focused .line-number.cursor-line-no-selection, .editor.is-focused .line.cursor-line {
+atom-text-editor.editor.is-focused .line-number.cursor-line-no-selection, .editor.is-focused .line.cursor-line {
   background-color: rgba(255, 255, 255, 0.1);
 }
 
-.comment {
+.syntax--comment {
   font-style: italic;
   color: #9A9A9A;
 }
 
-.constant {
+.syntax--constant {
   color: #3C98D9;
 }
 
-.entity {
+.syntax--entity {
   color: #BCDBFF;
 }
 
-.keyword {
+.syntax--keyword {
   color: rgba(229, 173, 148, 0.96);
 }
 
-.storage {
+.syntax--storage {
   color: #99CF50;
 }
 
-.string {
+.syntax--string {
   color: #8BB664;
 }
 
-.support {
+.syntax--support {
   color: #BFABCB;
 }
 
-.variable {
+.syntax--variable {
   color: #68A9EB;
 }
 
-.invalid.deprecated {
+.syntax--invalid.syntax--deprecated {
   font-style: italic;
   text-decoration: underline;
   color: #FD5FF1;
 }
 
-.invalid.illegal {
+.syntax--invalid.syntax--illegal {
   color: #FD5FF1;
   background-color: rgba(86, 45, 86, 0.75);
 }
 
-.text .source {
+.syntax--text .syntax--source {
   background-color: rgba(177, 179, 186, 0.03);
 }
 
-.entity.other.inherited-class {
+.syntax--entity.syntax--other.syntax--inherited-class {
   color: #FBFFF7;
 }
 
-.string.quoted .source {
+.syntax--string.syntax--quoted .syntax--source {
   color: #DAEFA3;
 }
 
-.string .constant {
+.syntax--string .syntax--constant {
   color: #DDF2A4;
 }
 
-.string.regexp {
+.syntax--string.syntax--regexp {
   color: #E9C062;
 }
 
-.string.regexp .constant.character.escape, .string.regexp .source.ruby.embedded, .string.regexp .string.regexp.arbitrary-repitition {
+.syntax--string.syntax--regexp .syntax--constant.syntax--character.syntax--escape, .syntax--string.syntax--regexp .syntax--source.syntax--ruby.syntax--embedded, .syntax--string.syntax--regexp .syntax--string.syntax--regexp.syntax--arbitrary-repitition {
   color: #CF7D34;
 }
 
-.string .variable {
+.syntax--string .syntax--variable {
   color: #E1EBBB;
 }
 
-.support.function {
+.syntax--support.syntax--function {
   color: #DAD085;
 }
 
-.support.constant {
+.syntax--support.syntax--constant {
   color: #A7CFA3;
 }
 
-.meta.preprocessor.c {
+.syntax--meta.syntax--preprocessor.syntax--c {
   color: #8996A8;
 }
 
-.meta.preprocessor.c .keyword {
+.syntax--meta.syntax--preprocessor.syntax--c .syntax--keyword {
   color: #AFC4DB;
 }
 
-.entity.name.type {
+.syntax--entity.syntax--name.syntax--type {
   text-decoration: underline;
   color: #B5D8F6;
 }
 
-.meta.cast {
+.syntax--meta.syntax--cast {
   font-style: italic;
   color: #676767;
 }
 
-.meta.sgml.html .meta.doctype, .meta.sgml.html .meta.doctype .entity, .meta.sgml.html .meta.doctype .string, .meta.xml-processing, .meta.xml-processing .entity, .meta.xml-processing .string {
+.syntax--meta.syntax--sgml.syntax--html .syntax--meta.syntax--doctype, .syntax--meta.syntax--sgml.syntax--html .syntax--meta.syntax--doctype .syntax--entity, .syntax--meta.syntax--sgml.syntax--html .syntax--meta.syntax--doctype .syntax--string, .syntax--meta.syntax--xml-processing, .syntax--meta.syntax--xml-processing .syntax--entity, .syntax--meta.syntax--xml-processing .syntax--string {
   color: #494949;
 }
 
-.meta.tag, .meta.tag .entity {
+.syntax--meta.syntax--tag, .syntax--meta.syntax--tag .syntax--entity {
   color: #89BDFF;
 }
 
-.source .entity.name.tag, .source .entity.other.attribute-name, .meta.tag.inline, .meta.tag.inline .entity {
+.syntax--source .syntax--entity.syntax--name.syntax--tag, .syntax--source .syntax--entity.syntax--other.syntax--attribute-name, .syntax--meta.syntax--tag.syntax--inline, .syntax--meta.syntax--tag.syntax--inline .syntax--entity {
   color: #E0C589;
 }
 
-.entity.name.tag.namespace, .entity.other.attribute-name.namespace {
+.syntax--entity.syntax--name.syntax--tag.syntax--namespace, .syntax--entity.syntax--other.syntax--attribute-name.syntax--namespace {
   color: #E18964;
 }
 
-.meta.selector.css .entity.name.tag {
+.syntax--meta.syntax--selector.syntax--css .syntax--entity.syntax--name.syntax--tag {
   color: #CDA367;
 }
 
-.meta.selector.css .entity.other.attribute-name.tag.pseudo-class {
+.syntax--meta.syntax--selector.syntax--css .syntax--entity.syntax--other.syntax--attribute-name.syntax--tag.syntax--pseudo-class {
   color: #8F9D6A;
 }
 
-.meta.selector.css .entity.other.attribute-name.id {
+.syntax--meta.syntax--selector.syntax--css .syntax--entity.syntax--other.syntax--attribute-name.syntax--id {
   color: #918BAB;
 }
 
-.meta.selector.css .entity.other.attribute-name.class {
+.syntax--meta.syntax--selector.syntax--css .syntax--entity.syntax--other.syntax--attribute-name.syntax--class {
   color: #DED087;
 }
 
-.support.type.property-name.css {
+.syntax--support.syntax--type.syntax--property-name.syntax--css {
   color: #C3C5B5;
 }
 
-.meta.property-group .support.constant.property-value.css, .meta.property-value .support.constant.property-value.css {
+.syntax--meta.syntax--property-group .syntax--support.syntax--constant.syntax--property-value.syntax--css, .syntax--meta.syntax--property-value .syntax--support.syntax--constant.syntax--property-value.syntax--css {
   color: #F9EFC4;
 }
 
-.meta.preprocessor.at-rule .keyword.control.at-rule {
+.syntax--meta.syntax--preprocessor.syntax--at-rule .syntax--keyword.syntax--control.syntax--at-rule {
   color: #8693A5;
 }
 
-.meta.property-value .support.constant.named-color.css, .meta.property-value .constant {
+.syntax--meta.syntax--property-value .syntax--support.syntax--constant.syntax--named-color.syntax--css, .syntax--meta.syntax--property-value .syntax--constant {
   color: #DDB8AB;
 }
 
-.meta.constructor.argument.css {
+.syntax--meta.syntax--constructor.syntax--argument.syntax--css {
   color: #8F9D6A;
 }
 
-.meta.diff, .meta.diff.header {
+.syntax--meta.syntax--diff, .syntax--meta.syntax--diff.syntax--header {
   font-style: italic;
   color: #F8F8F8;
   background-color: #0E2231;
 }
 
-.markup.deleted {
+.syntax--markup.syntax--deleted {
   color: #F8F8F8;
   background-color: #420E09;
 }
 
-.markup.changed {
+.syntax--markup.syntax--changed {
   color: #F8F8F8;
   background-color: #4A410D;
 }
 
-.markup.inserted {
+.syntax--markup.syntax--inserted {
   color: #F8F8F8;
   background-color: #253B22;
 }
 
-.markup.italic {
+.syntax--markup.syntax--italic {
   font-style: italic;
   color: #E9C062;
 }
 
-.markup.bold {
+.syntax--markup.syntax--bold {
   font-weight: bold;
   color: #E9C062;
 }
 
-.markup.underline {
+.syntax--markup.syntax--underline {
   text-decoration: underline;
   color: #E18964;
 }
 
-.markup.quote {
+.syntax--markup.syntax--quote {
   font-style: italic;
   color: #E1D4B9;
   background-color: rgba(254, 224, 156, 0.07);
 }
 
-.markup.heading, .markup.heading .entity {
+.syntax--markup.syntax--heading, .syntax--markup.syntax--heading .syntax--entity {
   color: #FEDCC5;
   background-color: #632D04;
 }
 
-.markup.list {
+.syntax--markup.syntax--list {
   color: #E1D4B9;
 }
 
-.markup.raw {
+.syntax--markup.syntax--raw {
   color: #578BB3;
   background-color: rgba(177, 179, 186, 0.03);
 }
 
-.markup .comment {
+.syntax--markup .syntax--comment {
   font-style: italic;
   color: #F67B37;
 }
 
-.meta.separator {
+.syntax--meta.syntax--separator {
   color: #60A633;
   background-color: #242424;
 }
 
-.meta.line.entry.logfile, .meta.line.exit.logfile {
+.syntax--meta.syntax--line.syntax--entry.syntax--logfile, .syntax--meta.syntax--line.syntax--exit.syntax--logfile {
   background-color: rgba(238, 238, 238, 0.16);
 }
 
-.meta.line.error.logfile {
+.syntax--meta.syntax--line.syntax--error.syntax--logfile {
   background-color: #751012;
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "code-school",
   "theme": "syntax",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "Code School 2 theme for Atom",
   "repository": "https://github.com/leejarvis/atom-code-school-theme",
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">=1.13"
   }
 }


### PR DESCRIPTION
To be able to use the newer versions of atom without deprecation warnings I replaced all selectors.
See this for more details: http://blog.atom.io/2016/11/14/removing-shadow-dom-boundary-from-text-editor-elements.html